### PR TITLE
UI Update

### DIFF
--- a/src/gscreenshot/__init__.py
+++ b/src/gscreenshot/__init__.py
@@ -57,7 +57,8 @@ class main_window(threading.Thread):
             "on_button_selectarea_clicked": self.button_select_area_or_window_clicked,
             "on_button_saveas_clicked": self.button_saveas_clicked,
             "on_button_about_clicked": self.button_about_clicked,
-            "on_button_quit_clicked": self.button_quit_clicked}
+            "on_button_quit_clicked": self.button_quit_clicked,
+            "on_button_copy_clicked": self.handle_copy_action}
 
         self.builder.connect_signals(dic)
 

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -63,7 +63,7 @@ Version: 3.0.1
             <property name="margin_left">5</property>
             <property name="margin_top">6</property>
             <property name="margin_bottom">6</property>
-            <property name="label" translatable="yes">Take Screenshot of...</property>
+            <property name="label" translatable="yes">Take screenshot of...</property>
             <attributes>
               <attribute name="weight" value="heavy"/>
             </attributes>
@@ -212,7 +212,6 @@ Version: 3.0.1
                   <object class="GtkSpinButton" id="spinbutton1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="margin_left">17</property>
                     <property name="caps_lock_warning">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">adjustment1</property>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -9,11 +9,7 @@ Version: 3.0.1
 -->
 <interface>
   <requires lib="gtk+" version="3.6"/>
-  <object class="GtkAdjustment" id="adjustment1">
-    <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
+  <object class="GtkAccelGroup" id="accelgroup-copy"/>
   <object class="GtkMenu" id="menu_saveas_additional_actions">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -24,9 +20,15 @@ Version: 3.0.1
         <property name="can_focus">False</property>
         <property name="use_underline">True</property>
         <property name="use_stock">True</property>
+        <property name="accel_group">accelgroup-copy</property>
         <signal name="activate" handler="on_button_copy_clicked" swapped="no"/>
       </object>
     </child>
+  </object>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="upper">100</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkWindow" id="window_main">
     <property name="visible">True</property>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -14,6 +14,20 @@ Version: 3.0.1
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkMenu" id="menu_saveas_additional_actions">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkImageMenuItem">
+        <property name="label">gtk-copy</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_underline">True</property>
+        <property name="use_stock">True</property>
+        <signal name="activate" handler="on_button_copy_clicked" swapped="no"/>
+      </object>
+    </child>
+  </object>
   <object class="GtkWindow" id="window_main">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -26,46 +40,13 @@ Version: 3.0.1
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkOverlay">
+          <object class="GtkImage" id="image1">
+            <property name="width_request">225</property>
+            <property name="height_request">200</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <child>
-              <object class="GtkImage" id="image1">
-                <property name="width_request">225</property>
-                <property name="height_request">200</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="vexpand">True</property>
-              </object>
-              <packing>
-                <property name="index">-1</property>
-              </packing>
-            </child>
-            <child type="overlay">
-              <object class="GtkButtonBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="valign">start</property>
-                <property name="layout_style">start</property>
-                <child>
-                  <object class="GtkButton">
-                    <property name="label">gtk-copy</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="opacity">0.73999999999999999</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="on_button_copy_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-              </object>
-            </child>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -233,6 +214,7 @@ Version: 3.0.1
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
+                    <property name="non_homogeneous">True</property>
                   </packing>
                 </child>
               </object>
@@ -247,20 +229,56 @@ Version: 3.0.1
                 <property name="can_focus">False</property>
                 <property name="layout_style">spread</property>
                 <child>
-                  <object class="GtkButton" id="button_saveas">
-                    <property name="label">gtk-save-as</property>
+                  <object class="GtkButtonBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="border_width">5</property>
-                    <property name="use_underline">True</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="layout_style">start</property>
+                    <child>
+                      <object class="GtkButton" id="button_saveas">
+                        <property name="label">gtk-save-as</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="use_underline">True</property>
+                        <property name="use_stock">True</property>
+                        <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                        <property name="secondary">True</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkMenuButton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="focus_on_click">False</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">start</property>
+                        <property name="popup">menu_saveas_additional_actions</property>
+                        <property name="use_popover">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                        <property name="secondary">True</property>
+                        <property name="non_homogeneous">True</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
                     <property name="position">0</property>
+                    <property name="non_homogeneous">True</property>
                   </packing>
                 </child>
                 <child>
@@ -278,6 +296,7 @@ Version: 3.0.1
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
+                    <property name="non_homogeneous">True</property>
                   </packing>
                 </child>
               </object>
@@ -288,7 +307,7 @@ Version: 3.0.1
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">5</property>
           </packing>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -198,6 +198,7 @@ Version: 3.0.1
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">start</property>
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="button_about">
@@ -227,6 +228,7 @@ Version: 3.0.1
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="halign">end</property>
                 <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkButtonBox">

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -115,7 +115,7 @@ Version: 3.0.1
                 <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton1">
-                    <property name="label" translatable="yes">Hide gscreenshot Window</property>
+                    <property name="label" translatable="yes">Hide gscreenshot</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
@@ -141,6 +141,7 @@ Version: 3.0.1
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="margin_right">5</property>
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkLabel" id="label11">
@@ -193,42 +194,12 @@ Version: 3.0.1
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_top">10</property>
-            <property name="column_homogeneous">True</property>
-            <child>
-              <object class="GtkButtonBox">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="layout_style">start</property>
-                <child>
-                  <object class="GtkButton" id="button_about">
-                    <property name="label">gtk-about</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="border_width">5</property>
-                    <property name="use_underline">True</property>
-                    <property name="use_stock">True</property>
-                    <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                    <property name="non_homogeneous">True</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
-              </packing>
-            </child>
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
+                <property name="hexpand">True</property>
                 <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkButtonBox">
@@ -304,6 +275,36 @@ Version: 3.0.1
               </object>
               <packing>
                 <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkButton" id="button_about">
+                    <property name="label">gtk-about</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="border_width">5</property>
+                    <property name="use_underline">True</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                    <property name="non_homogeneous">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
               </packing>
             </child>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -21,71 +21,150 @@ Version: 3.0.1
     <property name="window_position">center</property>
     <signal name="destroy" handler="on_window_main_destroy" swapped="no"/>
     <child>
-      <object class="GtkVBox" id="vbox1">
+      <object class="GtkBox">
+        <property name="width_request">340</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="spacing">3</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkHBox" id="hbox1">
+          <object class="GtkImage" id="image1">
+            <property name="width_request">225</property>
+            <property name="height_request">200</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <child>
-              <object class="GtkVBox" id="vbox3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkImage" id="image1">
-                    <property name="width_request">200</property>
-                    <property name="height_request">200</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="padding">6</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="padding">6</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="padding">6</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkTable" id="table1">
+          <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="n_rows">4</property>
-            <property name="n_columns">2</property>
-            <property name="homogeneous">True</property>
+            <property name="margin_left">5</property>
+            <property name="margin_right">5</property>
+            <property name="column_homogeneous">True</property>
             <child>
-              <object class="GtkButton" id="button_about">
-                <property name="label">gtk-about</property>
+              <object class="GtkButton" id="button_all">
+                <property name="label" translatable="yes">All</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_selectarea">
+                <property name="label" translatable="yes">Selection</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_window">
+                <property name="label" translatable="yes">Window</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">1</property>
+                <property name="hexpand">True</property>
+                <property name="column_spacing">7</property>
+                <child>
+                  <object class="GtkSpinButton" id="spinbutton1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="caps_lock_warning">False</property>
+                    <property name="input_purpose">number</property>
+                    <property name="adjustment">adjustment1</property>
+                    <property name="climb_rate">1</property>
+                    <property name="numeric">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label11">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">4</property>
+                    <property name="margin_right">4</property>
+                    <property name="label" translatable="yes">Delay</property>
+                    <property name="justify">fill</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="checkbutton1">
+                <property name="label" translatable="yes">hide window</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="margin_left">3</property>
+                <property name="use_underline">True</property>
+                <property name="image_position">right</property>
+                <property name="active">True</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_saveas">
+                <property name="label">gtk-save-as</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
+                <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="y_options"/>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
@@ -101,134 +180,23 @@ Version: 3.0.1
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
                 <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="y_options"/>
               </packing>
             </child>
             <child>
-              <object class="GtkHBox" id="hbox3">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="label11">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">delay:</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="padding">7</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="spinbutton1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="caps_lock_warning">False</property>
-                    <property name="input_purpose">number</property>
-                    <property name="adjustment">adjustment1</property>
-                    <property name="climb_rate">1</property>
-                    <property name="numeric">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="padding">6</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options">GTK_FILL</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="checkbutton1">
-                <property name="label" translatable="yes">hide window</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="right_attach">2</property>
-                <property name="x_options">GTK_FILL</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_saveas">
-                <property name="label">gtk-save-as</property>
+              <object class="GtkButton" id="button_about">
+                <property name="label">gtk-about</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
                 <property name="use_underline">True</property>
                 <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
+                <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">3</property>
-                <property name="bottom_attach">4</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_window">
-                <property name="label" translatable="yes">Window</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
-              </object>
-              <packing>
+                <property name="left_attach">1</property>
                 <property name="top_attach">2</property>
-                <property name="bottom_attach">3</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_selectarea">
-                <property name="label" translatable="yes">Selection</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="top_attach">1</property>
-                <property name="bottom_attach">2</property>
-                <property name="y_options"/>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_all">
-                <property name="label" translatable="yes">All</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="y_options"/>
               </packing>
             </child>
           </object>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -56,14 +56,17 @@ Version: 3.0.1
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="button_all">
-            <property name="label" translatable="yes">All</property>
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="border_width">5</property>
-            <property name="use_underline">True</property>
-            <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin_left">5</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
+            <property name="label" translatable="yes">Take Screenshot of...</property>
+            <attributes>
+              <attribute name="weight" value="heavy"/>
+            </attributes>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -72,35 +75,83 @@ Version: 3.0.1
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="button_selectarea">
-            <property name="label" translatable="yes">Selection</property>
+          <object class="GtkButtonBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="border_width">5</property>
-            <property name="use_underline">True</property>
-            <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">expand</property>
+            <child>
+              <object class="GtkButton" id="button_all">
+                <property name="label" translatable="yes">Everything</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_selectarea">
+                <property name="label" translatable="yes">Selection</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_window">
+                <property name="label" translatable="yes">Window</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="border_width">5</property>
+                <property name="use_underline">True</property>
+                <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
+            <property name="fill">False</property>
             <property name="position">2</property>
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="button_window">
-            <property name="label" translatable="yes">Window</property>
+          <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="border_width">5</property>
-            <property name="use_underline">True</property>
-            <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin_left">5</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
+            <property name="label" translatable="yes">Options</property>
+            <attributes>
+              <attribute name="weight" value="heavy"/>
+            </attributes>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -186,7 +237,7 @@ Version: 3.0.1
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="padding">4</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -8,7 +8,7 @@ Version: 3.0.1
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.2"/>
+  <requires lib="gtk+" version="3.6"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -31,10 +31,12 @@ Version: 3.0.1
             <property name="height_request">200</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
           </object>
           <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
             <property name="padding">6</property>
             <property name="position">0</property>
           </packing>
@@ -97,7 +99,7 @@ Version: 3.0.1
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
-                <property name="layout_style">start</property>
+                <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton1">
                     <property name="label" translatable="yes">Hide gscreenshot Window</property>
@@ -106,13 +108,13 @@ Version: 3.0.1
                     <property name="receives_default">False</property>
                     <property name="margin_left">3</property>
                     <property name="use_underline">True</property>
-                    <property name="image_position">right</property>
+                    <property name="image_position">bottom</property>
                     <property name="active">True</property>
                     <property name="draw_indicator">True</property>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -167,8 +169,9 @@ Version: 3.0.1
             </child>
           </object>
           <packing>
-            <property name="expand">False</property>
+            <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="padding">4</property>
             <property name="position">4</property>
           </packing>
         </child>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -26,18 +26,50 @@ Version: 3.0.1
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkImage" id="image1">
-            <property name="width_request">225</property>
-            <property name="height_request">200</property>
+          <object class="GtkOverlay">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="width_request">225</property>
+                <property name="height_request">200</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+              </object>
+              <packing>
+                <property name="index">-1</property>
+              </packing>
+            </child>
+            <child type="overlay">
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">start</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkButton">
+                    <property name="label">gtk-copy</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="opacity">0.73999999999999999</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="on_button_copy_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="padding">6</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 
+<!-- Generated with glade 3.20.0 
 
 Version: 3.0.1
 	Date: Sun Sep  3 23:46:12 2006
@@ -71,12 +71,13 @@ Version: 3.0.1
             <property name="homogeneous">True</property>
             <child>
               <object class="GtkButton" id="button_about">
-                <property name="label" translatable="yes">About</property>
+                <property name="label">gtk-about</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
                 <property name="use_underline">True</property>
+                <property name="use_stock">True</property>
                 <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
               </object>
               <packing>
@@ -89,12 +90,13 @@ Version: 3.0.1
             </child>
             <child>
               <object class="GtkButton" id="button_quit">
-                <property name="label" translatable="yes">Quit</property>
+                <property name="label">gtk-quit</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
                 <property name="use_underline">True</property>
+                <property name="use_stock">True</property>
                 <signal name="clicked" handler="on_button_quit_clicked" swapped="no"/>
               </object>
               <packing>
@@ -168,12 +170,13 @@ Version: 3.0.1
             </child>
             <child>
               <object class="GtkButton" id="button_saveas">
-                <property name="label" translatable="yes">Save As</property>
+                <property name="label">gtk-save-as</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
                 <property name="use_underline">True</property>
+                <property name="use_stock">True</property>
                 <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
               </object>
               <packing>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -32,6 +32,7 @@ Version: 3.0.1
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="title">gscreenshot</property>
+    <property name="resizable">False</property>
     <property name="window_position">center</property>
     <signal name="destroy" handler="on_window_main_destroy" swapped="no"/>
     <child>
@@ -112,7 +113,6 @@ Version: 3.0.1
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
-                <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton1">
                     <property name="label" translatable="yes">Hide gscreenshot</property>
@@ -142,7 +142,7 @@ Version: 3.0.1
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_right">5</property>
-                <property name="layout_style">start</property>
+                <property name="layout_style">center</property>
                 <child>
                   <object class="GtkLabel" id="label11">
                     <property name="visible">True</property>
@@ -200,7 +200,6 @@ Version: 3.0.1
                 <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="hexpand">True</property>
-                <property name="layout_style">spread</property>
                 <child>
                   <object class="GtkButtonBox">
                     <property name="visible">True</property>
@@ -283,7 +282,7 @@ Version: 3.0.1
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="layout_style">start</property>
+                <property name="homogeneous">True</property>
                 <child>
                   <object class="GtkButton" id="button_about">
                     <property name="label">gtk-about</property>
@@ -312,6 +311,7 @@ Version: 3.0.1
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
+            <property name="pack_type">end</property>
             <property name="position">5</property>
           </packing>
         </child>

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -8,7 +8,7 @@ Version: 3.0.1
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.0"/>
+  <requires lib="gtk+" version="3.2"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -176,6 +176,7 @@ Version: 3.0.1
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_top">10</property>
             <property name="column_homogeneous">True</property>
             <child>
               <object class="GtkButtonBox">

--- a/src/gscreenshot/resources/gui/glade/main.glade
+++ b/src/gscreenshot/resources/gui/glade/main.glade
@@ -22,7 +22,6 @@ Version: 3.0.1
     <signal name="destroy" handler="on_window_main_destroy" swapped="no"/>
     <child>
       <object class="GtkBox">
-        <property name="width_request">340</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
@@ -41,21 +40,82 @@ Version: 3.0.1
           </packing>
         </child>
         <child>
+          <object class="GtkButton" id="button_all">
+            <property name="label" translatable="yes">All</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="border_width">5</property>
+            <property name="use_underline">True</property>
+            <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button_selectarea">
+            <property name="label" translatable="yes">Selection</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="border_width">5</property>
+            <property name="use_underline">True</property>
+            <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button_window">
+            <property name="label" translatable="yes">Window</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="border_width">5</property>
+            <property name="use_underline">True</property>
+            <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">5</property>
-            <property name="margin_right">5</property>
             <property name="column_homogeneous">True</property>
             <child>
-              <object class="GtkButton" id="button_all">
-                <property name="label" translatable="yes">All</property>
+              <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_all_clicked" swapped="no"/>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton1">
+                    <property name="label" translatable="yes">Hide gscreenshot Window</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="margin_left">3</property>
+                    <property name="use_underline">True</property>
+                    <property name="image_position">right</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -63,46 +123,29 @@ Version: 3.0.1
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button_selectarea">
-                <property name="label" translatable="yes">Selection</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_selectarea_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_window">
-                <property name="label" translatable="yes">Window</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <signal name="clicked" handler="on_button_window_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkGrid">
+              <object class="GtkButtonBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="margin_left">1</property>
-                <property name="hexpand">True</property>
-                <property name="column_spacing">7</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkLabel" id="label11">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">Delay</property>
+                    <property name="justify">fill</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                    <property name="non_homogeneous">True</property>
+                  </packing>
+                </child>
                 <child>
                   <object class="GtkSpinButton" id="spinbutton1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="margin_left">17</property>
                     <property name="caps_lock_warning">False</property>
                     <property name="input_purpose">number</property>
                     <property name="adjustment">adjustment1</property>
@@ -110,100 +153,108 @@ Version: 3.0.1
                     <property name="numeric">True</property>
                   </object>
                   <packing>
-                    <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                    <property name="non_homogeneous">True</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkLabel" id="label11">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_left">4</property>
-                    <property name="margin_right">4</property>
-                    <property name="label" translatable="yes">Delay</property>
-                    <property name="justify">fill</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkCheckButton" id="checkbutton1">
-                <property name="label" translatable="yes">hide window</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="margin_left">3</property>
-                <property name="use_underline">True</property>
-                <property name="image_position">right</property>
-                <property name="active">True</property>
-                <property name="draw_indicator">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">0</property>
               </packing>
             </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_homogeneous">True</property>
             <child>
-              <object class="GtkButton" id="button_saveas">
-                <property name="label">gtk-save-as</property>
+              <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
+                <property name="can_focus">False</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkButton" id="button_about">
+                    <property name="label">gtk-about</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="border_width">5</property>
+                    <property name="use_underline">True</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="button_quit">
-                <property name="label">gtk-quit</property>
+              <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_button_quit_clicked" swapped="no"/>
+                <property name="can_focus">False</property>
+                <property name="layout_style">spread</property>
+                <child>
+                  <object class="GtkButton" id="button_saveas">
+                    <property name="label">gtk-save-as</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="border_width">5</property>
+                    <property name="use_underline">True</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="on_button_saveas_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="button_quit">
+                    <property name="label">gtk-quit</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="border_width">5</property>
+                    <property name="use_underline">True</property>
+                    <property name="use_stock">True</property>
+                    <signal name="clicked" handler="on_button_quit_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="button_about">
-                <property name="label">gtk-about</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="border_width">5</property>
-                <property name="use_underline">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_button_about_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="top_attach">0</property>
               </packing>
             </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">5</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
This declutters the UI a bit, adds room for additional functionality in a submenu of save, and switches out several of the buttons to use the GTK stock buttons, which also (to my understanding) makes them use the local language and locale.

This hopefully also makes the application functionality more clear by moving controls into labelled sections.

![image](https://cloud.githubusercontent.com/assets/2584772/14696627/c592532a-074a-11e6-8bd4-f4380af317f2.png)
