### PR TITLE
Avoid desktop effects by going transparent

### DIFF
--- a/src/gscreenshot/frontend/gtk.py
+++ b/src/gscreenshot/frontend/gtk.py
@@ -29,6 +29,7 @@ class Controller(object):
 
     def take_screenshot(self, app_method):
         if self._hide:
+            self._window.set_opacity(0)
             self._window.hide()
 
         while Gtk.events_pending():
@@ -38,6 +39,7 @@ class Controller(object):
         screenshot = app_method(self._delay)
         self._show_preview(screenshot)
 
+        self._window.set_opacity(1)
         self._window.show_all()
 
     def handle_keypress(self, widget=None, event=None, *args):


### PR DESCRIPTION
Resolves #24 

This makes the window fully transparent before hiding it, which avoids getting caught by desktop effects in most cases.