### PR TITLE
Auto-navigate to last-used save directory

### DIFF
--- a/src/gscreenshot/__init__.py
+++ b/src/gscreenshot/__init__.py
@@ -33,6 +33,7 @@ class Gscreenshot(object):
             screenshooter = Scrot()
 
         self.screenshooter = screenshooter
+        self.last_save_directory = os.path.expanduser("~")
 
     def screenshot_full_display(self, delay=0):
         """
@@ -142,10 +143,14 @@ class Gscreenshot(object):
         supported_formats = self.get_supported_formats()
 
         if actual_file_ext in supported_formats:
+            self.last_save_directory = os.path.dirname(filename)
             image.save(filename, actual_file_ext.upper())
             return True
         else:
             return False
+
+    def get_last_save_directory(self):
+        return self.last_save_directory
 
     def quit(self):
         """

--- a/src/gscreenshot/frontend/gtk.py
+++ b/src/gscreenshot/frontend/gtk.py
@@ -95,6 +95,7 @@ class Controller(object):
         cancelled = False
         save_dialog = FileSaveDialog(
                 self._app.get_time_filename(),
+                self._app.get_last_save_directory(),
                 self._window
                 )
 
@@ -185,8 +186,9 @@ class Controller(object):
 
 class FileSaveDialog(object):
 
-    def __init__(self, default_filename=None, parent=None):
+    def __init__(self, default_filename=None, default_folder=None, parent=None):
         self.default_filename = default_filename
+        self.default_folder = default_folder
         self.parent = parent
 
     def run(self):
@@ -210,6 +212,9 @@ class FileSaveDialog(object):
 
         if self.default_filename is not None:
             chooser.set_current_name(self.default_filename)
+
+        if self.default_folder is not None:
+            chooser.set_current_folder(self.default_folder)
 
         chooser.set_do_overwrite_confirmation(True)
 


### PR DESCRIPTION
Simple quality of life improvement if you're taking multiple screenshots and putting them in the same folder. The file chooser will now remember the last directory you saved to and navigate back to it the next time you hit save. It resets back to the home directory every time you open the program.