### PR TITLE
Update slop.py for slop 5.3.28

### DIFF
--- a/src/gscreenshot/selector/slop.py
+++ b/src/gscreenshot/selector/slop.py
@@ -50,7 +50,7 @@ class Slop(object):
         slop
         """
         try:
-            proc_output = subprocess.check_output(['slop', '--nodecoration'])
+            proc_output = subprocess.check_output(['slop', '--nodecorations'])
         except subprocess.CalledProcessError:
             return None
 


### PR DESCRIPTION
slop recently updated to 5.3.28, and the `nodecoration` flag appears to be now `nodecorations`. However, looking at slop 4.x (at least 4.3.21, the previous in Arch), the `nodecoration` flag never seemed to exist, and was `nodecorations` the whole time, so this change should continue to work in both versions.

See: https://github.com/naelstrof/slop