### PR TITLE
Handle selection cancel cleanly

### DIFF
--- a/src/gscreenshot/__init__.py
+++ b/src/gscreenshot/__init__.py
@@ -198,6 +198,9 @@ class Gscreenshot(object):
 
         return authors
 
+    def get_app_icon(self):
+        return Image.open('/usr/share/pixmaps/gscreenshot.png')
+
     def get_program_description(self):
 
         return "A simple screenshot tool"

--- a/src/gscreenshot/frontend/cli.py
+++ b/src/gscreenshot/frontend/cli.py
@@ -95,25 +95,28 @@ def run():
     else:
         gscreenshot.screenshot_full_display(args.delay)
 
-    if (args.filename is not False):
-        gscreenshot.save_last_image(args.filename)
-    elif (args.clip is False):
-        gscreenshot.save_last_image()
+    if (gscreenshot.get_last_image() is None):
+        pass
+    else:
+        if (args.filename is not False):
+            gscreenshot.save_last_image(args.filename)
+        elif (args.clip is False):
+            gscreenshot.save_last_image()
 
-    if (args.open is not False):
-        gscreenshot.open_last_screenshot()
+        if (args.open is not False):
+            gscreenshot.open_last_screenshot()
 
-    if (args.clip is not False):
-        tmp_file = os.path.join(
-                tempfile.gettempdir(),
-                'gscreenshot-cli-clip.png'
-                )
-        gscreenshot.save_last_image(tmp_file)
-        successful_clip = xclip_image_file(tmp_file)
+        if (args.clip is not False):
+            tmp_file = os.path.join(
+                    tempfile.gettempdir(),
+                    'gscreenshot-cli-clip.png'
+                    )
+            gscreenshot.save_last_image(tmp_file)
+            successful_clip = xclip_image_file(tmp_file)
 
-        if (not successful_clip):
-            print("Could not clip image! Xclip failed to run - is it installed?")
-            print("Your screenshot was saved to " + tmp_file)
+            if (not successful_clip):
+                print("Could not clip image! Xclip failed to run - is it installed?")
+                print("Your screenshot was saved to " + tmp_file)
 
 def main():
     with SignalHandler():

--- a/src/gscreenshot/frontend/gtk.py
+++ b/src/gscreenshot/frontend/gtk.py
@@ -186,6 +186,9 @@ class Controller(object):
 
     def _show_preview(self, image):
         # create an image buffer (pixbuf) and insert the grabbed image
+        if (image is None):
+            image = self._app.get_app_icon()
+
         previewPixbuf = self._image_to_pixbuf(image)
 
         allocation = self._preview.get_allocation()

--- a/src/gscreenshot/screenshooter/__init__.py
+++ b/src/gscreenshot/screenshooter/__init__.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from gscreenshot.selector import SelectionExecError, SelectionParseError
+from gscreenshot.selector import SelectionExecError, SelectionParseError, SelectionCancelled
 
 
 class Screenshooter(object):
@@ -53,6 +53,9 @@ class Screenshooter(object):
         """
         try:
             crop_box = self.selector.region_select()
+        except (SelectionCancelled) as e:
+            print("Selection was cancelled")
+            return
         except (OSError, SelectionExecError) as e:
             print("Failed to call region selector -- Using fallback region selection")
             self._grab_selection_fallback(delay)

--- a/src/gscreenshot/screenshooter/imlib_2.py
+++ b/src/gscreenshot/screenshooter/imlib_2.py
@@ -51,4 +51,4 @@ class Imlib2(Screenshooter):
             self._image = PIL.Image.open(self.tempfile)
             os.unlink(self.tempfile)
         except subprocess.CalledProcessError:
-            pass
+            self._image = None

--- a/src/gscreenshot/screenshooter/scrot.py
+++ b/src/gscreenshot/screenshooter/scrot.py
@@ -51,4 +51,4 @@ class Scrot(Screenshooter):
             self._image = PIL.Image.open(self.tempfile)
             os.unlink(self.tempfile)
         except subprocess.CalledProcessError:
-            pass
+            self._image = None

--- a/src/gscreenshot/selector/__init__.py
+++ b/src/gscreenshot/selector/__init__.py
@@ -6,3 +6,6 @@ class SelectionExecError(SelectionError):
 
 class SelectionParseError(SelectionError):
     pass
+
+class SelectionCancelled(SelectionError):
+    pass


### PR DESCRIPTION
#57 

Handles cancelling a selection operation cleanly, instead of throwing a nasty exception. This also fixes the double-cancel needed - gscreenshot was too good at using the fallback selector.