### PR TITLE
gscreenshot can invoke both gui and cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,10 @@ setup(name='gscreenshot',
     tests_require=test_requires,
     entry_points={
         'gui_scripts': [
-            'gscreenshot = gscreenshot.frontend.gtk:main'
+            'gscreenshot = gscreenshot.frontend:delegate'
         ],
         'console_scripts': [
-            'gscreenshot-cli = gscreenshot.frontend.cli:main'
+            'gscreenshot-cli = gscreenshot.frontend.cli:run'
         ]
     },
     test_suite='nose.collector',

--- a/src/gscreenshot/frontend/__init__.py
+++ b/src/gscreenshot/frontend/__init__.py
@@ -1,4 +1,7 @@
 import signal
+import sys
+import gscreenshot.frontend.cli
+import gscreenshot.frontend.gtk
 
 
 class SignalHandler(object):
@@ -18,3 +21,18 @@ class SignalHandler(object):
         # signal handlers, but that isn't functionality
         # that's needed right now, so we'll do nothing.
         pass
+
+class FrontendDelegator(object):
+    """
+    Delegates a gscreenshot call to the correct frontend
+    """
+    @staticmethod
+    def delegate():
+        with SignalHandler():
+            if (len(sys.argv) > 1):
+                gscreenshot.frontend.cli.run()
+            else:
+                gscreenshot.frontend.gtk.main()
+
+def delegate():
+    FrontendDelegator.delegate()

--- a/src/gscreenshot/frontend/cli.py
+++ b/src/gscreenshot/frontend/cli.py
@@ -1,5 +1,4 @@
 from gscreenshot import Gscreenshot
-from gscreenshot.frontend import SignalHandler
 from gscreenshot.screenshooter.exceptions import NoSupportedScreenshooterError
 
 import argparse
@@ -135,6 +134,3 @@ def run():
                 exit_code = 1
         sys.exit(exit_code)
 
-def main():
-    with SignalHandler():
-        run()

--- a/src/gscreenshot/frontend/gtk.py
+++ b/src/gscreenshot/frontend/gtk.py
@@ -11,7 +11,6 @@ from gi.repository import Gtk
 from gi.repository import GObject
 
 from gscreenshot import Gscreenshot
-from gscreenshot.frontend import SignalHandler
 from gscreenshot.screenshooter.exceptions import NoSupportedScreenshooterError
 
 from pkg_resources import resource_string, resource_filename
@@ -377,10 +376,9 @@ def main():
     window.connect("check-resize", handler.on_window_resize)
     window.set_icon_from_file(resource_filename('gscreenshot.resources.pixmaps', 'gscreenshot.png'))
 
-    with SignalHandler():
-        GObject.threads_init(); # Start background threads.
-        window.show_all()
-        Gtk.main()
+    GObject.threads_init(); # Start background threads.
+    window.show_all()
+    Gtk.main()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Update so calling `gscreenshot` can do both the CLI and the GUI, depending if parameters were passed.

This needs to be revamped because calling `gscreenshot-cli` takes and saves a screenshot, while with these changes `gscreenshot` opens the GUI - difference in behaviour.