### PR TITLE
Minor adjustment in scrot version obtaining strategy

### DIFF
--- a/src/gscreenshot/screenshooter/scrot.py
+++ b/src/gscreenshot/screenshooter/scrot.py
@@ -54,7 +54,7 @@ class Scrot(Screenshooter):
             scrot_version_output = subprocess.check_output(['scrot', '--version'])
             scrot_version_str = scrot_version_output.decode().strip().rsplit('.', maxsplit=1)[-1]
 
-            if float(scrot_version_str) >= 1:
+            if int(scrot_version_str.split('.')[0]) >= 1:
                 Scrot._supports_native_cursor_capture = True
             else:
                 Scrot._supports_native_cursor_capture = False


### PR DESCRIPTION
Latest release of "scrot" was tagged as 1.8.1. This caused problems when trying to parse version validation in scrot.py which apparently expected a two character descriptor. This fix generalizes scrot backend versioning validation.