### PR TITLE
Fix possible hanging when selecting boundary

### DIFF
--- a/src/gscreenshot/selector/__init__.py
+++ b/src/gscreenshot/selector/__init__.py
@@ -75,10 +75,11 @@ class RegionSelector():
         """
         try:
             with subprocess.Popen(
-                params,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
-                ) as selector_process:
+                    params,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
+            ) as selector_process:
 
                 try:
                     stdout, stderr = selector_process.communicate(timeout=60)


### PR DESCRIPTION
This is related to #177

After couple of hours of debugging I found the issue and managed to fix it, but sadly I'm not 100% sure why it fixes it. However, I tested it on both Wayland and X11 and it works on both of them.

Without providing `stdin`  the process hangs when calling `selector_process.communicate` and never actually does anything. When provided with `stdin` it correctly displays the selection overlay.